### PR TITLE
Feature/Add GPIO example

### DIFF
--- a/examples/gpio_continuity_test/Makefile
+++ b/examples/gpio_continuity_test/Makefile
@@ -1,0 +1,94 @@
+TARGET = main
+
+BUILD_DIR = ./build
+BASE_DIR  = ../..
+
+.SECONDEXPANSION:
+.PRECIOUS: $(BUILD_DIR)/ $(BUILD_DIR)%/
+
+# Define the linker script location and chip architecture.
+#LD_SCRIPT = stm32.ld
+LD_SCRIPT = $(BASE_DIR)/board/stm32f103xb.ld
+#STARTUP_CODE = board/startup_stm32f103xb.s
+MCU_SPEC  = cortex-m3
+
+# Toolchain definitions (ARM bare metal defaults)
+TOOLCHAIN = /usr/local
+CC = arm-none-eabi-gcc
+AS = arm-none-eabi-as
+LD = arm-none-eabi-ld
+OC = arm-none-eabi-objcopy
+OD = arm-none-eabi-objdump
+OS = arm-none-eabi-size
+
+# Assembly directives.
+ASFLAGS += -c
+#ASFLAGS += -O0
+ASFLAGS += -mcpu=$(MCU_SPEC)
+ASFLAGS += -mthumb
+ASFLAGS += -Wall
+# (Set error messages to appear on a single line.)
+ASFLAGS += -fmessage-length=0
+
+# C compilation directives
+REQ_CFLAGS += -mcpu=$(MCU_SPEC)
+REQ_CFLAGS += -mthumb
+REQ_CFLAGS += -Wall
+#CFLAGS += -g
+CFLAGS += -O3
+REQ_CFLAGS += --specs=nosys.specs
+# (Set error messages to appear on a single line.)
+REQ_CFLAGS += -fmessage-length=0
+# (Set system to ignore semihosted junk)
+REQ_CFLAGS += --specs=nano.specs
+
+# Linker directives.
+REQ_LFLAGS += -nostdlib
+#LFLAGS += -lgcc
+REQ_LFLAGS += -nostartfiles
+LFLAGS += --cref -Map $(BUILD_DIR)/$(TARGET).map
+REQ_LFLAGS += -T./$(LD_SCRIPT)
+
+STARTUP_SRC	= startup_stm32f103xb.s
+C_SRC    	= user_init.c
+APP_SRC    	= main.c
+
+include $(BASE_DIR)/board/board.mk
+include $(BASE_DIR)/os/os.mk
+include $(BASE_DIR)/hal/hal.mk
+
+OBJS = $(BUILD_DIR)/$(STARTUP_SRC:.s=.o)
+OBJS += $(addprefix $(BUILD_DIR)/, $(notdir $(C_SRC:.c=.o)))
+OBJS += $(BUILD_DIR)/$(APP_SRC:.c=.o)
+
+.PHONY: all, list
+all: $(BUILD_DIR)/$(TARGET).bin
+
+list: $(C_SRC) $(APP_SRC) $(STARTUP_SRC)
+	$(CC) -g -Wa,-adhln $(INCLUDE_DIRS) $(REQ_CFLAGS) $$(CFLAGS) $$^ > $(BUILD_DIR)/$(TARGET).lst
+
+$(BUILD_DIR)/%.o: $(BASE_DIR)/board/%.s | $$(@D)/
+	$(CC) -x assembler-with-cpp $(ASFLAGS) $< -o $@
+
+$(BUILD_DIR)/%.o: $(BASE_DIR)/board/%.S | $$(@D)/
+	$(CC) -x assembler-with-cpp $(ASFLAGS) $< -o $@
+
+$(BUILD_DIR)/%.o: %.c | $$(@D)/
+	$(CC) -c $(INCLUDE_DIRS) $(REQ_CFLAGS) $(CFLAGS) $< -o $@
+
+$(BUILD_DIR)/$(TARGET).elf: $(OBJS)
+	$(LD) $^ $(REQ_LFLAGS) $(LFLAGS) -o $@
+
+$(BUILD_DIR)/$(TARGET).bin: $(BUILD_DIR)/$(TARGET).elf
+	$(OC) -S -O binary $< $@
+	$(OS) $<
+
+$(BUILD_DIR)/:
+	mkdir -p $@
+
+$(BUILD_DIR)%/:
+	mkdir -p $@
+
+.PHONY: clean
+clean:
+	rm -rf $(BUILD_DIR)

--- a/examples/gpio_continuity_test/main.c
+++ b/examples/gpio_continuity_test/main.c
@@ -1,0 +1,44 @@
+/*
+ * This program illustrates a simple usage for the GPIO Hardware Abstraction Layer.
+ * 
+ * It implements a Continuity Test function (from a Multimeter) using as probes the
+ * PA_1 pin and the GND pin. The led will be ON if the continuity is detected and off
+ * otherwise.
+ */
+
+#include <stdint.h>
+#include "virtual_timer.h"
+#include "reactor.h"
+#include "gpio.h"
+#include "uart.h"
+#include "cmsis_gcc.h"
+
+
+hcos_base_int_t read_pin_cb(void) {
+    /* If zero voltage is detected at probe (GND is connected), there is continuity */
+    if (gpio_read_pin(GPIOA, 1) == 0) {
+        /* Let's turn the led ON! */
+        gpio_clear_pin(GPIOC, 13);
+    } else {
+        gpio_set_pin(GPIOC, 13);
+    }
+    
+    return 0;
+}
+
+int main(void) {
+    gpio_init();
+    /* Configure probe pin as input (the second probe should be GND) */
+    gpio_set_pin_mode(GPIOA, 1, generate_mode(IN_PULLUP, SPEED_50_MHZ));
+    /* Configure led pin as output */
+    gpio_set_pin_mode(GPIOC, 13, generate_mode(OUT_GP_PUSHPULL, SPEED_50_MHZ));
+    /* Write default value to led (OFF) -> ON (low level on STM32F103 Bluepill) means continuity detected */
+    gpio_set_pin(GPIOC, 13);
+
+    /* In this example, we'll use polling to read the state of the probe every 10 ms */
+    vt_add_non_rt_handler(read_pin_cb, 10, 1);
+
+    reactor_start();
+
+    return 0;
+}

--- a/examples/gpio_continuity_test/user_init.c
+++ b/examples/gpio_continuity_test/user_init.c
@@ -1,0 +1,7 @@
+#include <stdint.h>
+#include <stm32f103xb.h>
+
+
+void
+user_init(void) {
+}


### PR DESCRIPTION
This PR add a usage example for the GPIO HAL.

A Continuity Test function (from a Multimeter) is implemented using as probes the PA_1 pin and the GND pin. The led will be ON if the continuity is detected and OFF otherwise.